### PR TITLE
Add case for COSMO

### DIFF
--- a/src/blockpop_uncons.jl
+++ b/src/blockpop_uncons.jl
@@ -218,6 +218,8 @@ function newton_basis(n, d, supp; e=1e-5, solver="Mosek")
                 model = Model(optimizer_with_attributes(SDPT3.Optimizer))
              elseif solver == "SDPNAL"
                 model = Model(optimizer_with_attributes(SDPNAL.Optimizer))
+             elseif solver == "COSMO"
+                model = Model(optimizer_with_attributes(COSMO.Optimizer))
              else
                 @error "The solver is currently not supported!"
                 return nothing


### PR DESCRIPTION
Simple change in `blockpop_uncons.jl` adding a missing case for COSMO.
Without this it seemed to be impossible to solve any problems or examples using COSMO (even the first unconstrained case in the readme).